### PR TITLE
feat(notification): Notification Settings page with toggles (#161)

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -11,6 +11,8 @@ import FindMembers from "./FindMembers";
 import ProfilePage from "./ProfilePage";
 import EditProfilePage from "./EditProfilePage";
 import SettingsPage from "./SettingsPage";
+import NotificationSettingsPage from "./NotificationSettingsPage";
+
 
 
 function App() {
@@ -21,6 +23,7 @@ function App() {
             <Route path="/profilepage" element={<ProfilePage />} />
             <Route path="/edit-profile" element={<EditProfilePage />} />
             <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/settings/notifications" element={<NotificationSettingsPage />} />
             <Route path="/viewboards" element ={<ViewBoard />} />
             <Route path="/boards/:id" element={<BoardDetail />} />
             <Route path="/boards/:id/members" element={<MembersList />} />

--- a/my-app/src/NotificationSettingsPage.css
+++ b/my-app/src/NotificationSettingsPage.css
@@ -1,0 +1,57 @@
+.NotifPage {
+  max-width: 400px;
+  margin: 24px auto 80px auto;
+  padding: 16px;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  color: #000;
+}
+
+/* back arrow box */
+.notif-header {
+  margin-bottom: 24px;
+}
+
+.notif-back {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+  border: 1px solid #000;
+  background: #fff;
+  color: #000;
+  font-size: 20px;
+  line-height: 1;
+  text-decoration: none;
+}
+
+/* Each notification row */
+.notif-row {
+  border: 1px solid #000;
+  background: #fff;
+  padding: 16px;
+  margin-bottom: 24px;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* Text on the left ("Board Updates", etc.) */
+.notif-label {
+  font-size: 1rem;
+  color: #000;
+}
+
+/* Toggle button on the right ("On"/"Off") */
+.notif-toggle {
+  min-width: 80px;
+  border: 1px solid #000;
+  background: #000;
+  color: #fff;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 12px 16px;
+  text-align: center;
+  cursor: pointer;
+}

--- a/my-app/src/NotificationSettingsPage.js
+++ b/my-app/src/NotificationSettingsPage.js
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import "./NotificationSettingsPage.css";
+
+export default function NotificationSettingsPage() {
+  // Local toggle states for each notification type
+  const [boardUpdatesOn, setBoardUpdatesOn] = useState(true);
+  const [messagesOn, setMessagesOn] = useState(true);
+  const [followersOn, setFollowersOn] = useState(true);
+
+  return (
+    <div className="NotifPage">
+      {/* Back arrow at top */}
+      <header className="notif-header">
+        <Link to="/settings" className="notif-back">
+          ←
+        </Link>
+      </header>
+
+      {/* Row: Board Updates */}
+      <div className="notif-row">
+        <div className="notif-label">Board Updates</div>
+        <button
+          className="notif-toggle"
+          onClick={() => setBoardUpdatesOn(!boardUpdatesOn)}
+        >
+          {boardUpdatesOn ? "On" : "Off"}
+        </button>
+      </div>
+
+      {/* Row: New Messages */}
+      <div className="notif-row">
+        <div className="notif-label">New Messages</div>
+        <button
+          className="notif-toggle"
+          onClick={() => setMessagesOn(!messagesOn)}
+        >
+          {messagesOn ? "On" : "Off"}
+        </button>
+      </div>
+
+      {/* Row: New Follower */}
+      <div className="notif-row">
+        <div className="notif-label">New Follower</div>
+        <button
+          className="notif-toggle"
+          onClick={() => setFollowersOn(!followersOn)}
+        >
+          {followersOn ? "On" : "Off"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/SettingsPage.css
+++ b/my-app/src/SettingsPage.css
@@ -11,6 +11,13 @@
   margin-bottom: 24px;
 }
 
+.settings-link {
+  text-decoration: none;
+  color: #000;
+  display: block;
+}
+
+
 .settings-back {
   display: inline-flex;
   justify-content: center;

--- a/my-app/src/SettingsPage.js
+++ b/my-app/src/SettingsPage.js
@@ -14,9 +14,9 @@ export default function SettingsPage() {
       </header>
 
       {/* Settings blocks */}
-      <div className="settings-block">
+      <Link to="/settings/notifications" className="settings-block settings-link">
         Notification
-      </div>
+      </Link>
 
       <div className="settings-block">
         Profile Privacy


### PR DESCRIPTION
This PR implements Notification Settings for the user profile. (#161)

What was added:
- New page at `/settings/notifications`
- "Board Updates", "New Messages", "New Follower" notification options
- Each row has an On/Off toggle button that updates state live in the UI
- Back arrow navigation to go back to /settings
- Consistent black-outline wireframe style with the rest of the profile/settings flow

Also updated:
- Settings page now links "Notification" to `/settings/notifications`
- Added a new route in App.js for NotificationSettingsPage

This supports the backlog item "Notification Implementation".
