### PR TITLE
feat(settings): add Privacy Settings page (/settings/privacy) with interactive controls

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -12,6 +12,8 @@ import ProfilePage from "./ProfilePage";
 import EditProfilePage from "./EditProfilePage";
 import SettingsPage from "./SettingsPage";
 import NotificationSettingsPage from "./NotificationSettingsPage";
+import PrivacySettingsPage from "./PrivacySettingsPage";
+
 
 
 
@@ -24,6 +26,7 @@ function App() {
             <Route path="/edit-profile" element={<EditProfilePage />} />
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/settings/notifications" element={<NotificationSettingsPage />} />
+            <Route path="/settings/privacy" element={<PrivacySettingsPage />} />
             <Route path="/viewboards" element ={<ViewBoard />} />
             <Route path="/boards/:id" element={<BoardDetail />} />
             <Route path="/boards/:id/members" element={<MembersList />} />

--- a/my-app/src/PrivacySettingsPage.css
+++ b/my-app/src/PrivacySettingsPage.css
@@ -1,0 +1,56 @@
+.PrivacyPage {
+  max-width: 400px;
+  margin: 24px auto 80px auto;
+  padding: 16px;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  color: #000;
+}
+
+/* back arrow box */
+.privacy-header {
+  margin-bottom: 24px;
+}
+
+.privacy-back {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+  border: 1px solid #000;
+  background: #fff;
+  color: #000;
+  font-size: 20px;
+  line-height: 1;
+  text-decoration: none;
+}
+
+/* Each row in the list */
+.privacy-row {
+  border: 1px solid #000;
+  background: #fff;
+  padding: 16px;
+  margin-bottom: 24px;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.privacy-label {
+  font-size: 1rem;
+  color: #000;
+}
+
+/* Right-side black button that shows current value */
+.privacy-toggle {
+  min-width: 100px;
+  border: 1px solid #000;
+  background: #000;
+  color: #fff;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 12px 16px;
+  text-align: center;
+  cursor: pointer;
+}

--- a/my-app/src/PrivacySettingsPage.js
+++ b/my-app/src/PrivacySettingsPage.js
@@ -1,0 +1,65 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import "./PrivacySettingsPage.css";
+
+export default function PrivacySettingsPage() {
+  // State variables for each setting
+  // 1. Profile Visibility (toggle between "Private" and "Public")
+  const [visibility, setVisibility] = useState("Private");
+
+  // 2. Who Can Message Me (cycle between options: Everyone / Friends Only)
+  const [canMessage, setCanMessage] = useState("Everyone");
+
+  // 3. Online Status (On/Off like a boolean)
+  const [onlineStatusOn, setOnlineStatusOn] = useState(true);
+
+  // Handlers:
+  const toggleVisibility = () => {
+    setVisibility((prev) => (prev === "Private" ? "Public" : "Private"));
+  };
+
+  const toggleCanMessage = () => {
+    setCanMessage((prev) =>
+      prev === "Everyone" ? "Friends Only" : "Everyone"
+    );
+  };
+
+  const toggleOnlineStatus = () => {
+    setOnlineStatusOn((prev) => !prev);
+  };
+
+  return (
+    <div className="PrivacyPage">
+      {/* Back arrow at top */}
+      <header className="privacy-header">
+        <Link to="/settings" className="privacy-back">
+          ←
+        </Link>
+      </header>
+
+      {/* Row: Profile Visibility */}
+      <div className="privacy-row">
+        <div className="privacy-label">Profile Visibility</div>
+        <button className="privacy-toggle" onClick={toggleVisibility}>
+          {visibility}
+        </button>
+      </div>
+
+      {/* Row: Who Can Message Me */}
+      <div className="privacy-row">
+        <div className="privacy-label">Who Can Message Me</div>
+        <button className="privacy-toggle" onClick={toggleCanMessage}>
+          {canMessage}
+        </button>
+      </div>
+
+      {/* Row: Online Status */}
+      <div className="privacy-row">
+        <div className="privacy-label">Online Status</div>
+        <button className="privacy-toggle" onClick={toggleOnlineStatus}>
+          {onlineStatusOn ? "On" : "Off"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/SettingsPage.js
+++ b/my-app/src/SettingsPage.js
@@ -18,9 +18,13 @@ export default function SettingsPage() {
         Notification
       </Link>
 
-      <div className="settings-block">
+      {/* Go to Privacy subpage */}
+      <Link
+        to="/settings/privacy"
+        className="settings-block settings-link"
+      >
         Profile Privacy
-      </div>
+      </Link>
 
     </div>
   );


### PR DESCRIPTION
This PR adds the Privacy Settings screen to the user profile Settings flow. #162 

- New route: `/settings/privacy`
- User can control:
  - Profile Visibility (Private / Public)
  - Who Can Message Me (Everyone / Friends Only)
  - Online Status (On / Off)
- Each setting is backed by local React state so the black button on the right updates live when clicked.
- Back arrow navigation returns to `/settings`.
- Updated Settings page to link "Profile Privacy" to this new subpage.

This continues the profile settings work (privacy & visibility).
