### PR TITLE
feat(profile): add DeleteProfilePage (/delete-profile) and connect Delete Profile action (#140)

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -13,6 +13,8 @@ import EditProfilePage from "./EditProfilePage";
 import SettingsPage from "./SettingsPage";
 import NotificationSettingsPage from "./NotificationSettingsPage";
 import PrivacySettingsPage from "./PrivacySettingsPage";
+import DeleteProfilePage from "./DeleteProfilePage";
+
 
 
 
@@ -27,6 +29,7 @@ function App() {
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/settings/notifications" element={<NotificationSettingsPage />} />
             <Route path="/settings/privacy" element={<PrivacySettingsPage />} />
+            <Route path="/delete-profile" element={<DeleteProfilePage />} />
             <Route path="/viewboards" element ={<ViewBoard />} />
             <Route path="/boards/:id" element={<BoardDetail />} />
             <Route path="/boards/:id/members" element={<MembersList />} />

--- a/my-app/src/DeleteProfilePage.css
+++ b/my-app/src/DeleteProfilePage.css
@@ -1,0 +1,58 @@
+.DeletePageOuter {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: #fff;
+  color: #000;
+}
+
+.DeletePageInner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+
+  max-width: 400px;
+  width: 100%;
+  padding: 16px;
+  text-align: center;
+}
+
+/* Big black button */
+.delete-confirm-btn {
+  border: 1px solid #000;
+  background: #000;
+  color: #fff;
+  font-size: 1rem;
+  line-height: 1.4;
+  min-width: 270px;
+  padding: 16px;
+  cursor: pointer;
+}
+
+.delete-confirm-btn[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* "Return to Home" link */
+.return-wrapper {
+  margin-top: 8px;
+}
+
+.return-link {
+  text-decoration: underline;
+  color: #000;
+  font-size: 0.9rem;
+}
+
+/* developer note text */
+.dev-hint {
+  font-size: 0.7rem;
+  color: #444;
+  max-width: 260px;
+  line-height: 1.3;
+}

--- a/my-app/src/DeleteProfilePage.js
+++ b/my-app/src/DeleteProfilePage.js
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import { Link /*, useNavigate */ } from "react-router-dom";
+import "./DeleteProfilePage.css";
+
+export default function DeleteProfilePage() {
+  const [deleted, setDeleted] = useState(false);
+  // const navigate = useNavigate(); // TODO: once auth/login exists
+
+  function handleDelete() {
+    // This is where we'd call the backend to permanently delete the account.
+    console.log("TODO: call API to delete user profile");
+    setDeleted(true);
+    alert("Profile deleted (placeholder).");
+
+    // After delete, we WANT to redirect the user to the sign-on / login page.
+    // That page hasn't been built yet by the auth teammate.
+    //
+    // In the future this will be:
+    // navigate("/login");
+  }
+
+  return (
+    <div className="DeletePageOuter">
+      <div className="DeletePageInner">
+
+        <button
+          className="delete-confirm-btn"
+          onClick={handleDelete}
+          disabled={deleted}
+        >
+          {deleted ? "Deleted" : "Delete Profile!"}
+        </button>
+
+        <div className="return-wrapper">
+          {/* Temporary: send user somewhere that exists in the app */}
+          <Link to="/profilepage" className="return-link">
+            Return to Home
+          </Link>
+        </div>
+
+        {!deleted && (
+          <div className="dev-hint">
+            (Later: this will actually delete the account,
+            log the user out, and redirect to sign-on.)
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/ProfilePage.js
+++ b/my-app/src/ProfilePage.js
@@ -87,9 +87,9 @@ export default function ProfilePage() {
           Settings
         </Link>
 
-        <button className="wide-button delete-btn">
+        <Link to="/delete-profile" className="wide-button delete-btn">
           Delete Profile
-        </button>
+        </Link>
       </section>
 
     </div>


### PR DESCRIPTION
This PR implements the first step of the "Delete Profile" flow (#140).

What was added:
- New route `/delete-profile`
- New DeleteProfilePage with:
  - A prominent "Delete Profile!" button
  - After click: we mark the profile as deleted, show an alert, and disable the button
  - A "Return to Home" link

- ProfilePage now links its "Delete Profile" button to `/delete-profile`

Behavior / limitations:
- Currently this is a front-end placeholder only
- We log to console instead of actually deleting a user account
- After deletion, we eventually want to redirect to the sign-on / login screen, but that flow is owned by the authentication team and isn't implemented yet. We left TODO comments in the code for that.

This gives us an end-to-end, demoable deletion flow in the UI that matches the story requirements, and we can hook up backend + auth later.
