### PR TITLE
feat(settings): add Change Password flow under Settings instead of Edit Profile (#193)

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -22,6 +22,7 @@ import NotificationSettingsPage from "./NotificationSettingsPage";
 import PrivacySettingsPage from "./PrivacySettingsPage";
 import DeleteProfilePage from "./DeleteProfilePage";
 import CreateBoard from "./CreateBoard";
+import ChangePasswordPage from "./ChangePasswordPage";
 
 
 
@@ -49,6 +50,7 @@ function App() {
             <Route path="/settings/notifications" element={<NotificationSettingsPage />} />
             <Route path="/settings/privacy" element={<PrivacySettingsPage />} />
             <Route path="/delete-profile" element={<DeleteProfilePage />} />
+            <Route path="/settings/change-password" element={<ChangePasswordPage />} />
             <Route path="/viewboards" element={<ViewBoard />} />
             <Route path="/browse" element={<ViewBoard />} />
             <Route path="/boards/:id" element={<BoardDetail />} />

--- a/my-app/src/ChangePasswordPage.css
+++ b/my-app/src/ChangePasswordPage.css
@@ -1,0 +1,114 @@
+.ChangePasswordPage {
+  min-height: 100vh;
+  background: #fafafa;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  color: #222;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+  box-sizing: border-box;
+  position: relative;
+}
+
+/* header with back and title */
+.change-header {
+  width: 100%;
+  max-width: 400px;
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 24px;
+  position: relative;
+}
+
+.change-back {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 10px;
+  background: #111;
+  color: #fff;
+  font-size: 20px;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.change-back:hover {
+  transform: translateY(-2px);
+  opacity: 0.9;
+}
+
+.change-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #111;
+  line-height: 44px;
+  margin: 0;
+}
+
+/* card box that holds inputs */
+.change-card {
+  width: 100%;
+  max-width: 400px;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.08);
+  padding: 24px;
+  display: grid;
+  row-gap: 20px;
+}
+
+/* label + input wrapper */
+.change-field {
+  display: grid;
+  row-gap: 8px;
+}
+
+.change-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #111;
+}
+
+.change-input {
+  width: 100%;
+  border: 1px solid #d0d0d0;
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-size: 0.9rem;
+  color: #111;
+  background: #fafafa;
+  box-sizing: border-box;
+}
+
+/* main CTA button */
+.change-save-btn {
+  width: 100%;
+  border: none;
+  border-radius: 14px;
+  font-weight: 600;
+  font-size: 16px;
+  color: #fff;
+  background: #2f6df6;
+  height: 52px;
+  box-shadow: 0 8px 20px rgba(47,109,246,0.25);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.change-save-btn:hover {
+  transform: translateY(-2px);
+  opacity: 0.95;
+  box-shadow: 0 10px 26px rgba(47,109,246,0.35);
+}
+
+@media (max-width: 600px) {
+  .change-header {
+    margin-bottom: 16px;
+  }
+}

--- a/my-app/src/ChangePasswordPage.js
+++ b/my-app/src/ChangePasswordPage.js
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./ChangePasswordPage.css";
+
+export default function ChangePasswordPage() {
+  const navigate = useNavigate();
+
+  const [pw1, setPw1] = useState("");
+  const [pw2, setPw2] = useState("");
+
+  function handleSave() {
+    if (!pw1 || !pw2) {
+      alert("Please enter your new password twice.");
+      return;
+    }
+    if (pw1 !== pw2) {
+      alert("Passwords do not match.");
+      return;
+    }
+
+    // In the future:
+    // - call backend API to update password
+    // - handle auth / re-login if needed
+    console.log("Password updated (mock). New password:", pw1);
+    alert("Your password has been updated (placeholder).");
+    navigate("/settings"); // go back to settings after success
+  }
+
+  return (
+    <div className="ChangePasswordPage">
+
+      {/* header with back button + title */}
+      <header className="change-header">
+        <button
+          className="change-back"
+          onClick={() => navigate("/settings")}
+        >
+          ←
+        </button>
+
+        <h1 className="change-title">Change Password</h1>
+      </header>
+
+      <div className="change-card">
+        {/* New Password */}
+        <div className="change-field">
+          <label className="change-label">New Password</label>
+          <input
+            className="change-input"
+            type="password"
+            placeholder="Enter new password"
+            value={pw1}
+            onChange={(e) => setPw1(e.target.value)}
+          />
+        </div>
+
+        {/* Confirm Password */}
+        <div className="change-field">
+          <label className="change-label">Confirm Password</label>
+          <input
+            className="change-input"
+            type="password"
+            placeholder="Re-enter new password"
+            value={pw2}
+            onChange={(e) => setPw2(e.target.value)}
+          />
+        </div>
+
+        <button className="change-save-btn" onClick={handleSave}>
+          Save Password
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/EditProfilePage.js
+++ b/my-app/src/EditProfilePage.js
@@ -51,16 +51,6 @@ export default function EditProfilePage() {
           />
         </div>
 
-        {/* New Password */}
-        <div className="edit-field">
-          <label className="edit-label">New Password</label>
-          <input
-            className="edit-input"
-            type="password"
-            placeholder="Enter new password"
-          />
-        </div>
-
         {/* About Me */}
         <div className="edit-field">
           <label className="edit-label">About Me:</label>

--- a/my-app/src/SettingsPage.js
+++ b/my-app/src/SettingsPage.js
@@ -21,6 +21,11 @@ export default function SettingsPage() {
         <Link to="/settings/privacy" className="settings-block">
           Profile Privacy
         </Link>
+
+        <Link to="/settings/change-password" className="settings-block">
+          Change Password
+        </Link>
+
       </div>
     </div>
   );


### PR DESCRIPTION
This PR moves password management out of Edit Profile and into Settings.

- New `ChangePasswordPage` at `/settings/change-password`
  - User enters new password twice
  - We verify both match before accepting
  - On success, we show a mock alert and navigate back to Settings
  - TODO markers are in place where backend/auth integration will go

- SettingsPage now includes a "Change Password" button that links to this new screen

- Removed the "New Password" field from EditProfilePage so Edit Profile now focuses only on public profile info (name, username, bio, background, interests, photo)

This implements the "change password" story (#141) in a way that matches the new Settings visual style (rounded cards, blue primary actions).